### PR TITLE
Update auction_watch.py

### DIFF
--- a/scripts/miner/auction_watch.py
+++ b/scripts/miner/auction_watch.py
@@ -133,7 +133,7 @@ async def _monitor(args: argparse.Namespace):
         args.step_alpha = args.max_alpha
 
     wallet = load_wallet(coldkey_name=args.wallet_name, hotkey_name=args.wallet_hotkey)
-    autobid = bool(wallet and args.validator_hotkey)
+    autobid = bool(wallet and args.source_hotkey)
 
     st = bt.AsyncSubtensor(network=args.network)
     await st.initialize()
@@ -300,7 +300,7 @@ async def _monitor(args: argparse.Namespace):
                 ok = await transfer_alpha(
                     subtensor=st,
                     wallet=wallet,
-                    hotkey_ss58=args.validator_hotkey,
+                    hotkey_ss58=args.source_hotkey,
                     origin_and_dest_netuid=args.netuid,
                     dest_coldkey_ss58=args.treasury,
                     amount=bt.Balance.from_tao(extra_alpha),


### PR DESCRIPTION
## Fix: Complete migration from validator-hotkey to source-hotkey in auction_watch.py

The script was failing with `AttributeError: 'Namespace' object has no attribute 'validator_hotkey'`.

It looks like the team started refactoring from `--validator-hotkey` to `--source-hotkey` but didn't finish updating all references in the code.

### Changes made:
- Updated `args.validator_hotkey` to `args.source_hotkey` in line 136
- Updated `args.validator_hotkey` to `args.source_hotkey` in line 248 (transfer_alpha call)

This completes the refactoring and makes the naming consistent throughout the script.

### Tested with:
```bash
python scripts/miner/auction_watch.py \
    --netuid 123 \
    --source-hotkey <my_hotkey>\
    --max-alpha 100 \
    --step-alpha 5 \
    --max-discount 8