### PR TITLE
Update contributor guidance to clarify `.codex/` directory structure.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This document summarizes common development practices for all services in this r
 
 ## Where to Look for Guidance (Per-Service Layout)
 - **`.feedback/`**: Task lists and priorities. *Read only*—never edit directly.
-- **`.codex/`** (inside each service directory, e.g., `WebUI/.codex/`, `Rest-Servers/.codex/`):
+- **`.codex/`**:
   - `instructions/`: Contributor mode docs, process notes, and service-specific instructions. Place all new and updated process documentation here, following the structure and naming conventions. See examples in this folder.
   - `implementation/`: Service-specific implementation notes and technical docs. Keep these in sync with code changes.
   - Other subfolders: `requests/`, `prototyping/`, etc. for planning, feedback, and prototyping notes.


### PR DESCRIPTION
Cleaned up a oops.